### PR TITLE
Support for models that doesn't have UART

### DIFF
--- a/source/PeripheralPins.c
+++ b/source/PeripheralPins.c
@@ -160,12 +160,16 @@ const PinMap PinMap_SPI_CS[] = {
 /************UART**************/
 const PinMap PinMap_UART_TX[] = {
     /* UART0 */
+#ifdef UART_0
     {PF6, UART_0, 0},
     {PE0, UART_0, 1},
+#endif
     /* UART1 */
+#ifdef UART_1
     {PF10, UART_1, 1},
     {PB9, UART_1, 2},
     {PE2, UART_1, 3},
+#endif
     /* USART0 */
     {PE10, USART_0, 0},
     {PE7, USART_0, 1},
@@ -194,12 +198,16 @@ const PinMap PinMap_UART_TX[] = {
 
 const PinMap PinMap_UART_RX[] = {
     /* UART0 */
+#ifdef UART_0
     {PF7, UART_0, 0},
     {PE1, UART_0, 1},
+#endif
     /* UART1 */
+#ifdef UART_1
     {PF11, UART_1, 1},
     {PB10, UART_1, 2},
     {PE3, UART_1, 3},
+#endif
     /* USART0 */
     {PE11, USART_0, 0},
     {PE6, USART_0, 1},


### PR DESCRIPTION
 Support for models that doesn't have UART like EFM32GG330F512.
